### PR TITLE
fix a leftover deep_get from the pydash update

### DIFF
--- a/aplot.py
+++ b/aplot.py
@@ -366,7 +366,7 @@ def main():
 
         for metric in metrics:
             engine = diagram.AxisGraph(diagram.Point((width, height)), DiagramOptions())
-            engine.update([py_.deep_get(value, metric) for value in parser.result.values()])
+            engine.update([py_.get(value, metric) for value in parser.result.values()])
             if hasattr(sys.stdout, 'buffer'):
                 engine.render(sys.stdout.buffer)
             else:


### PR DESCRIPTION
Fixes a `AttributeError: module 'pydash' has no attribute 'deep_get'`. User hyhilman already renamed most calls to `deep_get` in https://github.com/efenka/aplot/pull/1 - this changes the last occurance of the deprecated call.
Thanks for the excellent utility.