### PR TITLE
pydash changes

### DIFF
--- a/aplot.py
+++ b/aplot.py
@@ -135,7 +135,7 @@ class AtopParser(object):
         result = set()
 
         for entry in self.result.values():
-            py_.deep_map_values(entry, lambda __, path: result.add(tuple(path)))
+            py_.map_values_deep(entry, lambda __, path: result.add(tuple(path)))
 
         return sorted(result)
 


### PR DESCRIPTION
Changed in version 4.0.0: Renamed from deep_map_values to map_values_deep._


while running "metrics" got the exception: 
AttributeError: module 'pydash' has no attribute 'deep_map_values'
