### PR TITLE
Update pydash version to fix runtime error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 iso8601==0.1.12
-pydash==4.5.0
+pydash==5.0.0
 humanfriendly==4.12.1
 tabulate==0.8.2
 diagram==0.2.25


### PR DESCRIPTION
Just a quick fix to get it running again. 

`cgi.escape` that was used in the older `pydash` was deprecated