### PR TITLE
Parse data directly

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -9,7 +9,7 @@ The script parses atop binary data files directly (no `atop` binary required at 
 
 ### Requirements
 
-* Python 3.8+
+* Python 3.10+
 * A raw logfile recorded by __atop__. Install atop on Ubuntu/Debian (`apt-get install atop`) or RedHat/CentOS (`yum install atop`) — it ships with a cronjob that writes data to `/var/log/atop/atop_YYYYMMDD` every few minutes. Otherwise record manually with [`atop -w`](http://linux.die.net/man/1/atop).
 * Python dependencies: `atoparser`, `tabulate`, `pydash`, `diagram`
 

--- a/Readme.md
+++ b/Readme.md
@@ -1,106 +1,140 @@
-Read and show single metrics from [atop](http://www.atoptool.nl/) raw logs. This is for example nice to show average CPU load in a nice text mode diagram using unicode braille characters (what is the default) on login.
+Read and show single metrics from [atop](http://www.atoptool.nl/) raw logs. This is for example nice to show average CPU load in a nice text mode diagram using unicode braille characters on login.
 
-The script supports python3.5+. It allows to dump the data as csv, json or ascii table and to plot simple graphs via [gnuplot subprocess](http://www.gnuplot.info/) or [diagram](https://github.com/tehmaze/diagram).
+The script parses atop binary data files directly (no `atop` binary required at read time). It can dump data as CSV, JSON or ASCII table and plot simple graphs via [gnuplot](http://www.gnuplot.info/) or [diagram](https://github.com/tehmaze/diagram).
 
 ### Warning
 
-* __No batteries included__ ... this is just the code i use. __It's not actively maintained__. It's just here in case it's useful for somebody.
-* __Require same machine__ run this code in same machine when using atop write. sometimes atop can't decode the binary files _it seems different machine have different binary file, i was logging atop from raspberry pi(raspi-os) and process it with virtualbox(ubuntu 17)_
+* __No batteries included__ ... this is just the code I use. __It's not actively maintained__. It's just here in case it's useful for somebody.
+* __Require compatible atop version__ — binary files must be from atop 1.26. Files from different atop versions or architectures may not parse correctly.
 
 ### Requirements
 
-* This script extracts its data from a raw logfile that has been recorded by __atop__. If you install atop on a Ubuntu or RedHat / CentOS like linux distribution (`apt-get install atop` / `yum install atop`), it comes with a [cronjob](http://linux.die.net/man/1/crontab) which writes the required data to `/var/log/atop/atop_YYYYMMDD` (where YYYYMMDD reflects the date) every few minutes. Otherwise you may need to do this yourself using [`atop -w`](http://linux.die.net/man/1/atop).
+* Python 3.8+
+* A raw logfile recorded by __atop__. Install atop on Ubuntu/Debian (`apt-get install atop`) or RedHat/CentOS (`yum install atop`) — it ships with a cronjob that writes data to `/var/log/atop/atop_YYYYMMDD` every few minutes. Otherwise record manually with [`atop -w`](http://linux.die.net/man/1/atop).
+* Python dependencies: `atoparser`, `tabulate`, `pydash`, `diagram`
 
 ### Installation
 
-1. Checkout the repository and install via `pip3 install ./aplot` (where `./aplot` is a path to checkout).
-2. (optional) Add your preferred call to your `~/.profile` to show it on login.
+1. Checkout the repository and install via `pip3 install ./aplot` (where `./aplot` is the path to the checkout).
+2. (optional) Add your preferred call to `~/.profile` to show it on login.
 
 ### Usage
 
-    Usage:
+Global options (`-p`, `-e`, `-r`) can be placed before or after the subcommand name.
 
-      python3 -m aplot metrics [-c <cmd>] [-p <path>] [-e <time>] [-r <hours>]
-      python3 -m aplot (csv|json|table) [-c <cmd>] [-p <path>] [-e <time>] [-r <hours>] [<metric>...]
-      python3 -m aplot (diagram|gnuplot) [-c <cmd>] [-p <path>] [-e <time>] [-r <hours>] [-x <lines>] [-y <lines>] [<metric>...]
+```
+python3 -m aplot <subcommand> [options]
+```
 
-    Options:
+**Subcommands:**
 
-        diagram                       Print the results as a braille character diagram (default).
-        gnuplot                       Print the results using a gnuplot subprocess.
-        table                         Print the results as ascii table.
-        csv                           Print the results as csv table.
-        json                          Print the results as json datagram.
+| Subcommand | Description |
+|---|---|
+| `metrics` | Print all available metric paths |
+| `users` | Print all user IDs (and names) seen in the data |
+| `csv [metric...]` | Print results as CSV |
+| `json [metric...]` | Print results as JSON |
+| `table [metric...]` | Print results as an ASCII table |
+| `diagram [metric...]` | Plot results as a braille character diagram |
+| `gnuplot [metric...]` | Plot results using a gnuplot subprocess |
 
-        metrics                       Print a list of all possible metric_path's.
+**Options (available on all subcommands):**
 
-        -e <time>, --end=<time>       The latest value to plot in ISO8601 format. Defaults to now. [default: now]
-        -r <hours>, --range=<hours>   Number of hours, backwards from --stop, top plot. [default: 6]
-        -x <lines>, --width=<lines>   Width of plotted graphs in text lines. [default: 59]
-        -y <lines>, --height=<lines>  Height of plotted graphs in text lines. [default: 9]
-        -p <path>, --path=<path>      Path to atop raw logs with date placeholders. [default: /var/log/atop/atop_%Y%m%d]
-        -c <cmd>, --cmd <cmd>         Command to call with the raw files. [default: atop -f -r {path}]
+```
+-p <path>, --path <path>    Path to atop raw log file(s). Use strftime placeholders
+                            (%Y, %m, %d) for date-based file sets, or a direct path
+                            for a single file. [default: /var/log/atop/atop_%Y%m%d]
+-e <time>, --end <time>     Latest timestamp to include, in ISO 8601 format. [default: now]
+-r <hours>, --range <hours> Number of hours backwards from --end to include. [default: 6]
+```
 
+**Options for `csv`, `json`, `table`, `diagram`, `gnuplot`:**
 
-        <metric>...                   The metric to display. Defaults to display CPL.avg5
+```
+metric...                   One or more metric paths to display. [default: CPL.avg5]
+-u <user>, --user <user>    Show per-interval aggregated stats for a user (name or UID)
+                            instead of system metrics. Metrics default to all user fields.
+```
+
+**Additional options for `diagram` and `gnuplot`:**
+
+```
+-x <cols>, --width <cols>   Graph width in columns. [default: 59]
+-y <lines>, --height <lines> Graph height in lines. [default: 9]
+```
 
 #### Metrics
 
-Which metrics are availbale depends on your atop installation, but in general you can assume something like:
-* CPL.avg1, CPL.avg15, CPL.avg5, CPL.csw, CPL.intr, CPU.idle, CPU.irq, CPU.sys, CPU.user, CPU.wait
-* DSK.sd_.avio, DSK.sd_.busy, DSK.sd_.read, DSK.sd_.write
-* MEM.buff, MEM.cache, MEM.free, MEM.slab, MEM.tot
-* NET.eth_.pcki, NET.eth_.pcko, NET.eth_.si, NET.eth_.so
-* NET.network.deliv, NET.network.ipfrw, NET.network.ipi, NET.network.ipo
-* NET.transport.tcpi, NET.transport.tcpo, NET.transport.udpi, NET.transport.udpo
-* PAG.scan, PAG.stall, PAG.swin, PAG.swout, PRC.exit, PRC.proc, PRC.sys, PRC.user, PRC.zombie
-* SWP.free, SWP.tot, SWP.vmcom, SWP.vmlim
+Use `aplot metrics` to list available metrics for your data. Common ones:
+
+* `CPL.avg1`, `CPL.avg5`, `CPL.avg15`, `CPL.csw`, `CPL.intr`
+* `CPU.idle`, `CPU.irq`, `CPU.sys`, `CPU.user`, `CPU.wait`
+* `DSK.<name>.avio`, `DSK.<name>.busy`, `DSK.<name>.read`, `DSK.<name>.write`
+* `MEM.buff`, `MEM.cache`, `MEM.free`, `MEM.physmem`, `MEM.slab`
+* `NET.<iface>.pcki`, `NET.<iface>.pcko`, `NET.<iface>.si`, `NET.<iface>.so`
+* `NET.network.ipi`, `NET.network.ipo`, `NET.transport.tcpi`, `NET.transport.tcpo`
+* `PAG.scan`, `PAG.stall`, `PAG.swin`, `PAG.swout`
+* `PRC.exit`, `PRC.proc`, `SWP.free`, `SWP.tot`
+
+#### User metrics
+
+When `--user` is given, the following fields are available as metrics:
+
+| Field | Description |
+|---|---|
+| `procs` | Number of processes owned by the user in this interval |
+| `utime` | Aggregated user CPU ticks |
+| `stime` | Aggregated system CPU ticks |
+| `vmem` | Total virtual memory (bytes) |
+| `rmem` | Total resident memory (bytes) |
 
 ### Examples
 
-##### `$ ./aplot.py diagram`
-
-  ![example](example.png)
-
-
-##### Time range
+##### Default diagram (CPU load average)
 
 ```
-aplot csv -p 'data/atop_%Y%m%d' -e '2026-06-18T23:59:00' -r 168 CPL.avg5 CPU.user CPU.idle MEM.free SWP.free PAG.swin NET.eth0.pcki 2>&1 | head -20 && echo "..." && python3 -m aplot csv -p 'data/atop_%Y%m%d' -e '2026-06-18T23:59:00' -r 168 CPL.avg5 2>&1 | wc -l
+aplot diagram
 ```
 
+![example](example.png)
 
-##### `$ ./aplot.py json CPL.avg5 SWP.free MEM.free --range 1 | json_pp`
+##### CSV export over a date range
 
 ```
+aplot csv --path 'data/atop_%Y%m%d' --end '2026-06-18T23:59:00' --range 168 \
+    CPL.avg5 CPU.user CPU.idle MEM.free
+```
 
+##### JSON output
+
+```
+aplot json CPL.avg5 SWP.free MEM.free --range 1
+```
+
+```json
 {
-   "2016-08-06T12:09:57" : {
-      "CPL.avg5" : 0.14,
-      "MEM.free" : 878077542,
-      "SWP.free" : 15998753177
-   },
-   "2016-08-06T12:19:57" : {
-      "CPL.avg5" : 0.11,
-      "MEM.free" : 875560960,
-      "SWP.free" : 15998753177
-   },
-   "2016-08-06T12:29:57" : {
-      "CPL.avg5" : 0.1,
-      "MEM.free" : 877867827,
-      "SWP.free" : 15998753177
-   },
-   "2016-08-06T12:39:57" : {
-      "CPL.avg5" : 0.12,
-      "MEM.free" : 878811545,
-      "SWP.free" : 15998753177
-   },
-   "2016-08-06T12:49:57" : {
-      "CPL.avg5" : 0.05,
-      "MEM.free" : 879126118,
-      "SWP.free" : 15998753177
-   }
+   "2016-08-06T12:09:57": { "CPL.avg5": 0.14, "MEM.free": 878077542, "SWP.free": 15998753177 },
+   "2016-08-06T12:19:57": { "CPL.avg5": 0.11, "MEM.free": 875560960, "SWP.free": 15998753177 }
 }
+```
+
+##### List users seen in a specific file
+
+```
+aplot users --path data/atop_20260616
+```
+
+##### Per-user CPU and memory table
+
+```
+aplot table --path 'data/atop_%Y%m%d' --range 24 --user 1004
+aplot table --path 'data/atop_%Y%m%d' --range 24 --user alice utime stime
+```
+
+##### Single file (no date placeholder)
+
+```
+aplot csv --path data/atop_20260616 CPL.avg5
 ```
 
 ### Related

--- a/Readme.md
+++ b/Readme.md
@@ -1,12 +1,12 @@
-Read and show single metrics from [atop](http://www.atoptool.nl/) raw logs. This is for example nice to show average CPU load in a nice text mode diagram using unicode braille characters (what is the default) on login. 
+Read and show single metrics from [atop](http://www.atoptool.nl/) raw logs. This is for example nice to show average CPU load in a nice text mode diagram using unicode braille characters (what is the default) on login.
 
 The script supports python3.5+. It allows to dump the data as csv, json or ascii table and to plot simple graphs via [gnuplot subprocess](http://www.gnuplot.info/) or [diagram](https://github.com/tehmaze/diagram).
- 
+
 ### Warning
 
 * __No batteries included__ ... this is just the code i use. __It's not actively maintained__. It's just here in case it's useful for somebody.
 * __Require same machine__ run this code in same machine when using atop write. sometimes atop can't decode the binary files _it seems different machine have different binary file, i was logging atop from raspberry pi(raspi-os) and process it with virtualbox(ubuntu 17)_
- 
+
 ### Requirements
 
 * This script extracts its data from a raw logfile that has been recorded by __atop__. If you install atop on a Ubuntu or RedHat / CentOS like linux distribution (`apt-get install atop` / `yum install atop`), it comes with a [cronjob](http://linux.die.net/man/1/crontab) which writes the required data to `/var/log/atop/atop_YYYYMMDD` (where YYYYMMDD reflects the date) every few minutes. Otherwise you may need to do this yourself using [`atop -w`](http://linux.die.net/man/1/atop).
@@ -19,30 +19,30 @@ The script supports python3.5+. It allows to dump the data as csv, json or ascii
 ### Usage
 
     Usage:
-    
+
       python3 -m aplot metrics [-c <cmd>] [-p <path>] [-e <time>] [-r <hours>]
       python3 -m aplot (csv|json|table) [-c <cmd>] [-p <path>] [-e <time>] [-r <hours>] [<metric>...]
       python3 -m aplot (diagram|gnuplot) [-c <cmd>] [-p <path>] [-e <time>] [-r <hours>] [-x <lines>] [-y <lines>] [<metric>...]
-    
+
     Options:
-    
+
         diagram                       Print the results as a braille character diagram (default).
         gnuplot                       Print the results using a gnuplot subprocess.
         table                         Print the results as ascii table.
         csv                           Print the results as csv table.
         json                          Print the results as json datagram.
-    
+
         metrics                       Print a list of all possible metric_path's.
-    
+
         -e <time>, --end=<time>       The latest value to plot in ISO8601 format. Defaults to now. [default: now]
         -r <hours>, --range=<hours>   Number of hours, backwards from --stop, top plot. [default: 6]
         -x <lines>, --width=<lines>   Width of plotted graphs in text lines. [default: 59]
         -y <lines>, --height=<lines>  Height of plotted graphs in text lines. [default: 9]
         -p <path>, --path=<path>      Path to atop raw logs with date placeholders. [default: /var/log/atop/atop_%Y%m%d]
         -c <cmd>, --cmd <cmd>         Command to call with the raw files. [default: atop -f -r {path}]
-    
-    
-        <metric>...                   The metric to display. Defaults to display CPL.avg5    
+
+
+        <metric>...                   The metric to display. Defaults to display CPL.avg5
 
 #### Metrics
 
@@ -58,9 +58,16 @@ Which metrics are availbale depends on your atop installation, but in general yo
 
 ### Examples
 
-##### `$ ./aplot.py diagram` 
- 
+##### `$ ./aplot.py diagram`
+
   ![example](example.png)
+
+
+##### Time range
+
+```
+aplot csv -p 'data/atop_%Y%m%d' -e '2026-06-18T23:59:00' -r 168 CPL.avg5 CPU.user CPU.idle MEM.free SWP.free PAG.swin NET.eth0.pcki 2>&1 | head -20 && echo "..." && python3 -m aplot csv -p 'data/atop_%Y%m%d' -e '2026-06-18T23:59:00' -r 168 CPL.avg5 2>&1 | wc -l
+```
 
 
 ##### `$ ./aplot.py json CPL.avg5 SWP.free MEM.free --range 1 | json_pp`

--- a/Readme.md
+++ b/Readme.md
@@ -131,6 +131,19 @@ aplot table --path 'data/atop_%Y%m%d' --range 24 --user 1004
 aplot table --path 'data/atop_%Y%m%d' --range 24 --user alice utime stime
 ```
 
+##### Hourly min/mean/max of CPU and memory for a user (requires [miller](https://miller.readthedocs.io/))
+
+```
+aplot csv --path 'data/atop_%Y%m%d' --end '2026-06-18T23:59' --range 168 \
+    --user 1004 utime stime vmem rmem \
+  | mlr --csv \
+    put '$hour = strftime(strptime($time, "%Y-%m-%dT%H:%M:%S"), "%Y-%m-%dT%H")' \
+    then stats1 -a min,mean,max -f utime,stime,vmem,rmem -g hour \
+    then format-values -f %.0f
+```
+
+Output columns: `hour`, then `utime_min`, `utime_mean`, `utime_max`, `stime_min`, `stime_mean`, `stime_max`, `vmem_min`, `vmem_mean`, `vmem_max`, `rmem_min`, `rmem_mean`, `rmem_max`. `utime`/`stime` are CPU ticks (1/100 s each); `vmem`/`rmem` are in bytes.
+
 ##### Single file (no date placeholder)
 
 ```

--- a/Readme.md
+++ b/Readme.md
@@ -69,12 +69,11 @@ Use `aplot metrics` to list available metrics for your data. Common ones:
 
 * `CPL.avg1`, `CPL.avg5`, `CPL.avg15`, `CPL.csw`, `CPL.intr`
 * `CPU.idle`, `CPU.irq`, `CPU.sys`, `CPU.user`, `CPU.wait`
-* `DSK.<name>.avio`, `DSK.<name>.busy`, `DSK.<name>.read`, `DSK.<name>.write`
-* `MEM.buff`, `MEM.cache`, `MEM.free`, `MEM.physmem`, `MEM.slab`
+* `DSK.<name>.avio`, `DSK.<name>.read`, `DSK.<name>.write`
+* `MEM.buff`, `MEM.cache`, `MEM.free`, `MEM.slab`, `MEM.tot`
 * `NET.<iface>.pcki`, `NET.<iface>.pcko`, `NET.<iface>.si`, `NET.<iface>.so`
-* `NET.network.ipi`, `NET.network.ipo`, `NET.transport.tcpi`, `NET.transport.tcpo`
 * `PAG.scan`, `PAG.stall`, `PAG.swin`, `PAG.swout`
-* `PRC.exit`, `PRC.proc`, `SWP.free`, `SWP.tot`
+* `PRC.exit`, `PRC.proc`, `SWP.free`, `SWP.tot`, `SWP.vmcom`, `SWP.vmlim`
 
 #### User metrics
 

--- a/aplot/__main__.py
+++ b/aplot/__main__.py
@@ -288,29 +288,26 @@ def main():
 
     now = datetime.now().replace(second=0, microsecond=0).isoformat()
 
-    global_opts = argparse.ArgumentParser(add_help=False)
-    global_opts.add_argument('-p', '--path', default='/var/log/atop/atop_%Y%m%d',
-                             help='Path to atop raw logs with date placeholders. (default: %(default)s)')
-    global_opts.add_argument('-e', '--end', default=now,
-                             help='Latest value to plot in ISO8601 format. (default: now)')
-    global_opts.add_argument('-r', '--range', type=int, default=6, dest='range',
-                             help='Hours backwards from --end to plot. (default: %(default)s)')
+    global_parser = argparse.ArgumentParser(add_help=False)
+    global_parser.add_argument('-p', '--path', default='/var/log/atop/atop_%Y%m%d')
+    global_parser.add_argument('-e', '--end', default=now)
+    global_parser.add_argument('-r', '--range', type=int, default=6, dest='range')
+    global_args, remaining = global_parser.parse_known_args()
 
-    parser = argparse.ArgumentParser(description='Atop log data analyzer.', parents=[global_opts])
+    parser = argparse.ArgumentParser(description='Atop log data analyzer.',
+                                     parents=[global_parser])
     subparsers = parser.add_subparsers(dest='command')
     subparsers.required = True
 
-    subparsers.add_parser('metrics', help="Print a list of all possible metric paths.",
-                          parents=[global_opts])
-    subparsers.add_parser('users', help="Print all user IDs (and names) seen in the data.",
-                          parents=[global_opts])
+    subparsers.add_parser('metrics', help="Print a list of all possible metric paths.")
+    subparsers.add_parser('users', help="Print all user IDs (and names) seen in the data.")
 
     for cmd, help_text in [
         ('csv',  'Print results as CSV.'),
         ('json', 'Print results as JSON.'),
         ('table', 'Print results as an ASCII table.'),
     ]:
-        sub = subparsers.add_parser(cmd, help=help_text, parents=[global_opts])
+        sub = subparsers.add_parser(cmd, help=help_text)
         sub.add_argument('metric', nargs='*', default=['CPL.avg5'],
                          help='Metrics to display. (default: CPL.avg5)')
         sub.add_argument('-u', '--user', metavar='USER',
@@ -320,7 +317,7 @@ def main():
         ('diagram', 'Print results as a braille character diagram.'),
         ('gnuplot', 'Print results using gnuplot.'),
     ]:
-        sub = subparsers.add_parser(cmd, help=help_text, parents=[global_opts])
+        sub = subparsers.add_parser(cmd, help=help_text)
         sub.add_argument('metric', nargs='*', default=['CPL.avg5'],
                          help='Metrics to display. (default: CPL.avg5)')
         sub.add_argument('-u', '--user', metavar='USER',
@@ -330,7 +327,7 @@ def main():
         sub.add_argument('-y', '--height', type=int, default=9,
                          help='Graph height in lines. (default: %(default)s)')
 
-    args = parser.parse_args()
+    args = parser.parse_args(remaining, namespace=global_args)
 
     end = datetime.fromisoformat(args.end)
     begin = end - timedelta(hours=args.range)

--- a/aplot/__main__.py
+++ b/aplot/__main__.py
@@ -4,7 +4,6 @@
 from datetime import datetime, timedelta
 from collections import OrderedDict
 import argparse
-import iso8601
 import re
 import sys
 import glob
@@ -268,7 +267,7 @@ def main():
 
     args = parser.parse_args()
 
-    end = iso8601.parse_date(args.end, default_timezone=None)
+    end = datetime.fromisoformat(args.end)
     begin = end - timedelta(hours=args.range)
     reader = AtopBinaryReader(args.path)
     metrics = getattr(args, 'metric', [])

--- a/aplot/__main__.py
+++ b/aplot/__main__.py
@@ -156,6 +156,46 @@ def _parse_sstat(data, pagesize):
     return result
 
 
+# Offsets within a 604-byte pstat record (verified empirically).
+# GEN sub-struct starts at 0, CPU at 256, MEM at 416.
+_PSTAT_SIZE = 604
+_PSTAT_PID_OFF = 0        # int32
+_PSTAT_RUID_OFF = 8       # int32
+_PSTAT_NAME_OFF = 44      # char[15] (PNAMLEN)
+_PSTAT_STATE_OFF = 60     # char
+_PSTAT_CPU_UTIME_OFF = 244   # count_t (int64, ticks); GEN is 244 bytes (not 256)
+_PSTAT_CPU_STIME_OFF = 252   # count_t
+_PSTAT_MEM_VMEM_OFF = 428    # count_t (pages): MEM@404 + vmem@24
+_PSTAT_MEM_RMEM_OFF = 436    # count_t (pages): MEM@404 + rmem@32
+
+
+def _parse_pstat(data, nprocs, pagesize, hertz, uid_filter=None):
+    """Parse per-process records and aggregate by uid.
+
+    Returns a dict keyed by uid, each value a dict with aggregated metrics.
+    If uid_filter is set, only that uid is included.
+    """
+    by_uid = {}
+    for i in range(nprocs):
+        base = i * _PSTAT_SIZE
+        ruid = struct.unpack_from('<i', data, base + _PSTAT_RUID_OFF)[0]
+        if uid_filter is not None and ruid != uid_filter:
+            continue
+        name = data[base + _PSTAT_NAME_OFF:base + _PSTAT_NAME_OFF + 15].rstrip(b'\x00').decode(errors='ignore')
+        utime = struct.unpack_from('<q', data, base + _PSTAT_CPU_UTIME_OFF)[0]
+        stime = struct.unpack_from('<q', data, base + _PSTAT_CPU_STIME_OFF)[0]
+        vmem = struct.unpack_from('<q', data, base + _PSTAT_MEM_VMEM_OFF)[0] * pagesize
+        rmem = struct.unpack_from('<q', data, base + _PSTAT_MEM_RMEM_OFF)[0] * pagesize
+
+        entry = by_uid.setdefault(ruid, {'procs': 0, 'utime': 0, 'stime': 0, 'vmem': 0, 'rmem': 0})
+        entry['procs'] += 1
+        entry['utime'] += utime
+        entry['stime'] += stime
+        entry['vmem'] += vmem
+        entry['rmem'] += rmem
+    return by_uid
+
+
 class AtopBinaryReader(object):
 
     def __init__(self, path_schema):
@@ -180,10 +220,9 @@ class AtopBinaryReader(object):
                 elif len(available_times) == file_index + 1:
                     yield file_time.strftime(self._path_schema)
 
-    def read(self, begin, end):
-        """Yield (datetime, metrics_dict) for each sample in [begin, end]."""
+    def _iter_records(self, begin, end):
+        """Low-level iterator yielding (ts, rec, sstat_raw, pstat_raw) for each sample."""
         from atoparser.structs import atop_1_26
-        import ctypes
 
         for path in self.required_file_paths(begin, end):
             try:
@@ -195,6 +234,7 @@ class AtopBinaryReader(object):
                 header = atop_1_26.Header()
                 f.readinto(header)
                 pagesize = header.pagesize
+                hertz = header.hertz
 
                 first_record = True
                 while True:
@@ -204,62 +244,87 @@ class AtopBinaryReader(object):
 
                     try:
                         sstat_raw = zlib.decompress(f.read(rec['scomplen']))
-                        f.read(rec['pcomplen'])  # skip pstat (per-process data)
+                        pstat_raw = zlib.decompress(f.read(rec['pcomplen']))
                     except zlib.error:
                         break
 
-                    ts = datetime.fromtimestamp(rec['curtime'])
-
-                    # Skip the first record in each file: it holds cumulative-since-boot
-                    # counters rather than per-interval deltas.
+                    # Skip the first record: it holds cumulative-since-boot counters.
                     if first_record:
                         first_record = False
                         continue
 
+                    ts = datetime.fromtimestamp(rec['curtime'])
                     if self._filter_by_time and (ts < begin or ts > end):
                         continue
 
-                    metrics = _parse_sstat(sstat_raw, pagesize)
-                    metrics['PRC'] = {
-                        'proc': rec['nlist'],
-                        'exit': rec['nexit'],
-                    }
-                    yield ts, metrics
+                    yield ts, rec, sstat_raw, pstat_raw, pagesize, hertz
+
+    def read(self, begin, end):
+        """Yield (datetime, metrics_dict) for each sample in [begin, end]."""
+        for ts, rec, sstat_raw, pstat_raw, pagesize, hertz in self._iter_records(begin, end):
+            metrics = _parse_sstat(sstat_raw, pagesize)
+            metrics['PRC'] = {
+                'proc': rec['nlist'],
+                'exit': rec['nexit'],
+            }
+            yield ts, metrics
+
+    def read_uids(self, begin, end):
+        """Return a set of all UIDs seen across all samples in [begin, end]."""
+        uids = set()
+        for ts, rec, sstat_raw, pstat_raw, pagesize, hertz in self._iter_records(begin, end):
+            by_uid = _parse_pstat(pstat_raw, rec['nlist'], pagesize, hertz)
+            uids.update(by_uid)
+        return uids
+
+    def read_user(self, begin, end, uid):
+        """Yield (datetime, user_metrics_dict) aggregated for a single uid."""
+        for ts, rec, sstat_raw, pstat_raw, pagesize, hertz in self._iter_records(begin, end):
+            by_uid = _parse_pstat(pstat_raw, rec['nlist'], pagesize, hertz, uid_filter=uid)
+            yield ts, by_uid.get(uid, {'procs': 0, 'utime': 0, 'stime': 0, 'vmem': 0, 'rmem': 0})
 
 
 def main():
 
     now = datetime.now().replace(second=0, microsecond=0).isoformat()
 
-    parser = argparse.ArgumentParser(description='Atop log data analyzer.')
-    parser.add_argument('-p', '--path', default='/var/log/atop/atop_%Y%m%d',
-                        help='Path to atop raw logs with date placeholders. (default: %(default)s)')
-    parser.add_argument('-e', '--end', default=now,
-                        help='Latest value to plot in ISO8601 format. (default: now)')
-    parser.add_argument('-r', '--range', type=int, default=6, dest='range',
-                        help='Hours backwards from --end to plot. (default: %(default)s)')
+    global_opts = argparse.ArgumentParser(add_help=False)
+    global_opts.add_argument('-p', '--path', default='/var/log/atop/atop_%Y%m%d',
+                             help='Path to atop raw logs with date placeholders. (default: %(default)s)')
+    global_opts.add_argument('-e', '--end', default=now,
+                             help='Latest value to plot in ISO8601 format. (default: now)')
+    global_opts.add_argument('-r', '--range', type=int, default=6, dest='range',
+                             help='Hours backwards from --end to plot. (default: %(default)s)')
 
+    parser = argparse.ArgumentParser(description='Atop log data analyzer.', parents=[global_opts])
     subparsers = parser.add_subparsers(dest='command')
     subparsers.required = True
 
-    subparsers.add_parser('metrics', help="Print a list of all possible metric paths.")
+    subparsers.add_parser('metrics', help="Print a list of all possible metric paths.",
+                          parents=[global_opts])
+    subparsers.add_parser('users', help="Print all user IDs (and names) seen in the data.",
+                          parents=[global_opts])
 
     for cmd, help_text in [
         ('csv',  'Print results as CSV.'),
         ('json', 'Print results as JSON.'),
         ('table', 'Print results as an ASCII table.'),
     ]:
-        sub = subparsers.add_parser(cmd, help=help_text)
+        sub = subparsers.add_parser(cmd, help=help_text, parents=[global_opts])
         sub.add_argument('metric', nargs='*', default=['CPL.avg5'],
                          help='Metrics to display. (default: CPL.avg5)')
+        sub.add_argument('-u', '--user', metavar='USER',
+                         help='Show per-interval aggregated stats for a user (name or UID).')
 
     for cmd, help_text in [
         ('diagram', 'Print results as a braille character diagram.'),
         ('gnuplot', 'Print results using gnuplot.'),
     ]:
-        sub = subparsers.add_parser(cmd, help=help_text)
+        sub = subparsers.add_parser(cmd, help=help_text, parents=[global_opts])
         sub.add_argument('metric', nargs='*', default=['CPL.avg5'],
                          help='Metrics to display. (default: CPL.avg5)')
+        sub.add_argument('-u', '--user', metavar='USER',
+                         help='Show per-interval aggregated stats for a user (name or UID).')
         sub.add_argument('-x', '--width', type=int, default=59,
                          help='Graph width in columns. (default: %(default)s)')
         sub.add_argument('-y', '--height', type=int, default=9,
@@ -272,9 +337,64 @@ def main():
     reader = AtopBinaryReader(args.path)
     metrics = getattr(args, 'metric', [])
 
-    result = OrderedDict()
-    for ts, data in reader.read(begin, end):
-        result[ts] = data
+    if args.command == 'users':
+        import pwd
+        uids = reader.read_uids(begin, end)
+        if not uids:
+            sys.stderr.write('empty result\n')
+            sys.exit(1)
+        for uid in sorted(uids):
+            try:
+                name = pwd.getpwuid(uid).pw_name
+            except KeyError:
+                name = ''
+            print(f'{uid}\t{name}' if name else str(uid))
+        return
+
+    user_arg = getattr(args, 'user', None)
+    if user_arg is not None:
+        try:
+            uid = int(user_arg)
+        except ValueError:
+            import pwd
+            try:
+                uid = pwd.getpwnam(user_arg).pw_uid
+            except KeyError:
+                sys.stderr.write(f'unknown user: {user_arg}\n')
+                sys.exit(1)
+        user_fields = ['procs', 'utime', 'stime', 'vmem', 'rmem']
+        user_metrics = args.metric if args.metric != ['CPL.avg5'] else user_fields
+        rows = list(reader.read_user(begin, end, uid))
+        if not rows:
+            sys.stderr.write('empty result\n')
+            sys.exit(1)
+        headers = ['time'] + user_metrics
+
+        if args.command == 'table':
+            from tabulate import tabulate
+            print(tabulate([[ts] + [data[m] for m in user_metrics] for ts, data in rows],
+                           headers=headers, tablefmt='plain'))
+        elif args.command == 'json':
+            from json import dumps
+            print(dumps({ts.isoformat(): {m: data[m] for m in user_metrics} for ts, data in rows}))
+        elif args.command == 'csv':
+            import csv
+            writer = csv.writer(sys.stdout)
+            writer.writerow(headers)
+            for ts, data in rows:
+                writer.writerow([ts.isoformat()] + [data[m] for m in user_metrics])
+        elif args.command in ('diagram', 'gnuplot'):
+            result = OrderedDict((ts, data) for ts, data in rows)
+            metrics = user_metrics
+            get_value = lambda value, metric: value[metric]
+        if args.command not in ('diagram', 'gnuplot'):
+            return
+
+    if user_arg is None:
+        result = OrderedDict()
+        for ts, data in reader.read(begin, end):
+            result[ts] = data
+        get_value = py_.get
 
     if not result:
         sys.stderr.write('empty result\n')
@@ -332,7 +452,7 @@ def main():
 
             for time, value in result.items():
                 process.stdin.write(b"%s\t%s\n" % (str(time.isoformat()).encode('utf-8'),
-                                                    str(py_.get(value, metric)).encode('utf-8')))
+                                                    str(get_value(value, metric)).encode('utf-8')))
 
             process.stdin.write(b"e\n")
             process.stdin.flush()
@@ -358,7 +478,7 @@ def main():
 
         for metric in metrics:
             engine = diagram.AxisGraph(diagram.Point((args.width, args.height)), DiagramOptions())
-            engine.update([py_.get(value, metric) for value in result.values()])
+            engine.update([get_value(value, metric) for value in result.values()])
             if hasattr(sys.stdout, 'buffer'):
                 engine.render(sys.stdout.buffer)
             else:

--- a/aplot/__main__.py
+++ b/aplot/__main__.py
@@ -1,37 +1,9 @@
 #!/usr/bin/env python3
 # coding: utf-8
 
-""" Atop log data analyzer.
-
-Usage:
-  {cmd} metrics [-p <path>] [-e <time>] [-r <hours>]
-  {cmd} (csv|json|table) [-p <path>] [-e <time>] [-r <hours>] [<metric>...]
-  {cmd} (diagram|gnuplot) [-p <path>] [-e <time>] [-r <hours>] [-x <lines>] [-y <lines>] [<metric>...]
-
-Options:
-
-    diagram                       Print the results as a braille character diagram (default).
-    gnuplot                       Print the results using a gnuplot subprocess.
-    table                         Print the results as ascii table.
-    csv                           Print the results as csv table.
-    json                          Print the results as json datagram.
-
-    metrics                       Print a list of all possible metric_path's.
-
-    -e <time>, --end=<time>       The latest value to plot in ISO8601 format. Defaults to now. [default: {now}]
-    -r <hours>, --range=<hours>   Number of hours, backwards from --stop, top plot. [default: 6]
-    -x <lines>, --width=<lines>   Width of plotted graphs in text lines. [default: 59]
-    -y <lines>, --height=<lines>  Height of plotted graphs in text lines. [default: 9]
-    -p <path>, --path=<path>      Path to atop raw logs with date placeholders. [default: /var/log/atop/atop_%Y%m%d]
-
-
-    <metric>...                   The metric to display. Defaults to display CPL.avg5
-
-
-"""
-
 from datetime import datetime, timedelta
 from collections import OrderedDict
+import argparse
 import iso8601
 import re
 import sys
@@ -258,25 +230,58 @@ class AtopBinaryReader(object):
 
 def main():
 
-    from docopt import docopt
-    arguments = docopt(__doc__.format(cmd=__file__,
-                                      now=datetime.now().replace(second=0, microsecond=0).isoformat()))
+    now = datetime.now().replace(second=0, microsecond=0).isoformat()
 
-    time_range = int(arguments['--range'])
-    metrics = arguments['<metric>'] or ['CPL.avg5']
-    end = iso8601.parse_date(arguments['--end'], default_timezone=None)
-    begin = end - timedelta(hours=time_range)
-    reader = AtopBinaryReader(arguments['--path'])
+    parser = argparse.ArgumentParser(description='Atop log data analyzer.')
+    parser.add_argument('-p', '--path', default='/var/log/atop/atop_%Y%m%d',
+                        help='Path to atop raw logs with date placeholders. (default: %(default)s)')
+    parser.add_argument('-e', '--end', default=now,
+                        help='Latest value to plot in ISO8601 format. (default: now)')
+    parser.add_argument('-r', '--range', type=int, default=6, dest='range',
+                        help='Hours backwards from --end to plot. (default: %(default)s)')
+
+    subparsers = parser.add_subparsers(dest='command')
+    subparsers.required = True
+
+    subparsers.add_parser('metrics', help="Print a list of all possible metric paths.")
+
+    for cmd, help_text in [
+        ('csv',  'Print results as CSV.'),
+        ('json', 'Print results as JSON.'),
+        ('table', 'Print results as an ASCII table.'),
+    ]:
+        sub = subparsers.add_parser(cmd, help=help_text)
+        sub.add_argument('metric', nargs='*', default=['CPL.avg5'],
+                         help='Metrics to display. (default: CPL.avg5)')
+
+    for cmd, help_text in [
+        ('diagram', 'Print results as a braille character diagram.'),
+        ('gnuplot', 'Print results using gnuplot.'),
+    ]:
+        sub = subparsers.add_parser(cmd, help=help_text)
+        sub.add_argument('metric', nargs='*', default=['CPL.avg5'],
+                         help='Metrics to display. (default: CPL.avg5)')
+        sub.add_argument('-x', '--width', type=int, default=59,
+                         help='Graph width in columns. (default: %(default)s)')
+        sub.add_argument('-y', '--height', type=int, default=9,
+                         help='Graph height in lines. (default: %(default)s)')
+
+    args = parser.parse_args()
+
+    end = iso8601.parse_date(args.end, default_timezone=None)
+    begin = end - timedelta(hours=args.range)
+    reader = AtopBinaryReader(args.path)
+    metrics = getattr(args, 'metric', [])
 
     result = OrderedDict()
     for ts, data in reader.read(begin, end):
         result[ts] = data
 
-    if not len(result):
+    if not result:
         sys.stderr.write('empty result\n')
         sys.exit(1)
 
-    elif arguments['metrics']:
+    if args.command == 'metrics':
 
         metric_paths = set()
         for entry in result.values():
@@ -284,20 +289,20 @@ def main():
         for path in sorted(metric_paths):
             print('.'.join(path))
 
-    elif arguments['table']:
+    elif args.command == 'table':
 
         from tabulate import tabulate
         print(tabulate([[time] + [py_.get(value, metric) for metric in metrics]
                         for time, value in result.items()],
                        ['time'] + metrics, tablefmt="plain"))
 
-    elif arguments['json']:
+    elif args.command == 'json':
 
         from json import dumps
         print(dumps({time.isoformat(): {metric: py_.get(value, metric) for metric in metrics}
                      for time, value in result.items()}))
 
-    elif arguments['csv']:
+    elif args.command == 'csv':
 
         import csv
         writer = csv.writer(sys.stdout)
@@ -305,17 +310,14 @@ def main():
         for time, value in result.items():
             writer.writerow([time.isoformat()] + [py_.get(value, metric) for metric in metrics])
 
-    elif arguments['gnuplot']:
+    elif args.command == 'gnuplot':
 
         for metric in metrics:
-
-            width = int(arguments['--width'])
-            height = int(arguments['--height'])
 
             import subprocess as sp
             process = sp.Popen(["gnuplot"], stdin=sp.PIPE)
 
-            process.stdin.write(b"set term dumb %d %d \n" % (width, height))
+            process.stdin.write(b"set term dumb %d %d \n" % (args.width, args.height))
             process.stdin.write(b"unset border \n")
             process.stdin.write(b"unset ytics \n")
             process.stdin.write(b"unset xtics \n")
@@ -338,12 +340,9 @@ def main():
             process.stdin.close()
             process.wait()
 
-    elif arguments['diagram']:
+    elif args.command == 'diagram':
 
         import diagram
-
-        width = int(arguments['--width'])
-        height = int(arguments['--height'])
 
         class DiagramOptions(object):
             axis = True
@@ -359,7 +358,7 @@ def main():
                 self.__dict__.update(kwargs)
 
         for metric in metrics:
-            engine = diagram.AxisGraph(diagram.Point((width, height)), DiagramOptions())
+            engine = diagram.AxisGraph(diagram.Point((args.width, args.height)), DiagramOptions())
             engine.update([py_.get(value, metric) for value in result.values()])
             if hasattr(sys.stdout, 'buffer'):
                 engine.render(sys.stdout.buffer)

--- a/aplot/__main__.py
+++ b/aplot/__main__.py
@@ -4,9 +4,9 @@
 """ Atop log data analyzer.
 
 Usage:
-  {cmd} metrics [-c <cmd>] [-p <path>] [-e <time>] [-r <hours>]
-  {cmd} (csv|json|table) [-c <cmd>] [-p <path>] [-e <time>] [-r <hours>] [<metric>...]
-  {cmd} (diagram|gnuplot) [-c <cmd>] [-p <path>] [-e <time>] [-r <hours>] [-x <lines>] [-y <lines>] [<metric>...]
+  {cmd} metrics [-p <path>] [-e <time>] [-r <hours>]
+  {cmd} (csv|json|table) [-p <path>] [-e <time>] [-r <hours>] [<metric>...]
+  {cmd} (diagram|gnuplot) [-p <path>] [-e <time>] [-r <hours>] [-x <lines>] [-y <lines>] [<metric>...]
 
 Options:
 
@@ -23,7 +23,6 @@ Options:
     -x <lines>, --width=<lines>   Width of plotted graphs in text lines. [default: 59]
     -y <lines>, --height=<lines>  Height of plotted graphs in text lines. [default: 9]
     -p <path>, --path=<path>      Path to atop raw logs with date placeholders. [default: /var/log/atop/atop_%Y%m%d]
-    -c <cmd>, --cmd <cmd>         Command to call with the raw files. [default: atop -f -r {{path}}]
 
 
     <metric>...                   The metric to display. Defaults to display CPL.avg5
@@ -37,231 +36,224 @@ import iso8601
 import re
 import sys
 import glob
-import decimal
-import humanfriendly
+import struct
+import zlib
 import pydash as py_
-import subprocess
 
 
-class AtopParser(object):
+# Struct layout constants derived empirically from atop 1.26 binary files.
+# All values little-endian. count_t fields are int64; cpunr is int32 (packed, no alignment pad).
 
-    _entry_regex = re.compile(r'^ATOP - (?P<HOST>\S+)\s*(?P<TIME>\d+/\d+/\d+\s+\d+:\d+:\d+)\s.*')
-    _metric_regex = re.compile(r'^(?P<metric>(PRC|CPU|CPL|MEM|SWP|PAG|DSK|NET))\s(?P<details>.+)$')
-    _field_regex = re.compile(r'\|\s+([^|\s]*)\s+([^|]+)\s+')
-
-    _size_fields = [('MEM', 'buff'),
-                    ('MEM', 'cache'),
-                    ('MEM', 'free'),
-                    ('MEM', 'slab'),
-                    ('MEM', 'tot'),
-                    ('SWP', 'free'),
-                    ('SWP', 'tot'),
-                    ('SWP', 'vmcom'),
-                    ('SWP', 'vmlim'),
-                    ('NET', 'si'),
-                    ('NET', 'so')]
-
-    _time_span_fields = [('DSK', 'avio'),
-                         ('PRC', 'sys'),
-                         ('PRC', 'user')]
-
-    _percentage_fields = [('CPU', 'idle'),
-                          ('CPU', 'irq'),
-                          ('CPU', 'sys'),
-                          ('CPU', 'user'),
-                          ('CPU', 'wait'),
-                          ('DSK', 'busy')]
-
-    _float_fields = [('CPL', 'avg1'),
-                     ('CPL', 'avg5'),
-                     ('CPL', 'avg15')]
-
-    _integer_fields = [('CPL', 'csw'),
-                       ('CPL', 'intr'),
-                       ('DSK', 'read'),
-                       ('DSK', 'write'),
-                       ('NET', 'pcki'),
-                       ('NET', 'pcko'),
-                       ('NET', 'si'),
-                       ('NET', 'so'),
-                       ('NET', 'deliv'),
-                       ('NET', 'ipfrw'),
-                       ('NET', 'ipi'),
-                       ('NET', 'ipo'),
-                       ('NET', 'tcpi'),
-                       ('NET', 'tcpo'),
-                       ('NET', 'udpi'),
-                       ('NET', 'udpo'),
-                       ('PAG', 'scan'),
-                       ('PAG', 'stall'),
-                       ('PAG', 'swin'),
-                       ('PAG', 'swout'),
-                       ('PRC', 'exit'),
-                       ('PRC', 'proc'),
-                       ('PRC', 'sys'),
-                       ('PRC', 'user'),
-                       ('PRC', 'zombie')]
-
-    def __init__(self, min_date=None, max_date=None):
-        self.min_date = min_date
-        self.max_date = max_date
-        self.current_time = None
-        self.current_data = None
-        self.result = OrderedDict()
-
-    def _reset_current_entry(self):
-        self.current_time = None
-        self.current_data = None
-
-    def _append_current_entry(self):
-        if self.current_data is not None:
-            self.result[self.current_time] = self.current_data
-        self._reset_current_entry()
-
-    def __enter__(self, ):
-        self._reset_current_entry()
-        return self
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-
-        if exc_type is None and exc_val is not None and exc_tb is not None:
-            self._append_current_entry()
-
-        return False
-
-    @property
-    def available_metrics_tuples(self):
-
-        result = set()
-
-        for entry in self.result.values():
-            py_.map_values_deep(entry, lambda __, path: result.add(tuple(path)))
-
-        return sorted(result)
-
-    @property
-    def available_metric_paths(self):
-
-        return ['.'.join(p) for p in self.available_metrics_tuples]
-
-    def _parse_field(self, field_metric, field_key, field_value):
-
-        try:
-
-            # sizes
-            if (field_metric, field_key) in self._size_fields:
-                return humanfriendly.parse_size(field_value)
-
-            # time spans
-            elif (field_metric, field_key) in self._time_span_fields:
-                return sum(humanfriendly.parse_timespan(v)
-                           if v else 0
-                           for v in re.findall(r'([\d,\.]+\s*\D+)', field_value))
-
-            # percentages
-            elif (field_metric, field_key) in self._percentage_fields:
-                return int(field_value.replace('%', '').strip())
-
-            # floats
-            elif (field_metric, field_key) in self._float_fields:
-                return float(decimal.Decimal(field_value))
-
-            # integers
-            elif (field_metric, field_key) in self._integer_fields:
-                return int(decimal.Decimal(field_value))
-
-        except ValueError:
-            pass
-
-    def add_line(self, atop_line):
-
-        match = self._entry_regex.match(atop_line)
-        if match:
-            # this is a new entry
-
-            if self.current_data is not None:
-                self._append_current_entry()
-
-            entry_time = datetime.strptime(match.group('TIME'), '%Y/%m/%d %H:%M:%S')
-
-            if self.min_date and entry_time < self.min_date:
-                return False
-
-            if self.max_date and entry_time > self.max_date:
-                return False
-
-            self.current_time = entry_time
-            self.current_data = {}
-
-            return True
-
-        elif self.current_data is not None:
-            # this is a new metric line
-
-            match = self._metric_regex.match(atop_line)
-            if match:
-
-                line_metric = match.group('metric')
-                line_details = match.group('details')
-                metric_name = None
-                row = {}
-
-                for metric_key, metric_value in (m.groups() for m in self._field_regex.finditer(line_details)):
-
-                    metric_key = metric_key.strip().replace('#', '') if metric_key.strip() else None
-                    metric_value = metric_value.strip() if metric_value.strip() else None
-
-                    if metric_key is None and metric_value is None:
-                        continue
-
-                    self.current_data[line_metric] = self.current_data.get(line_metric, {})
-
-                    if line_metric in ('NET', 'DSK'):
-
-                        if not metric_name:
-                            if line_metric == 'NET':
-                                metric_name = metric_key
-                            elif line_metric == 'DSK' and metric_key is None:
-                                metric_name = metric_value
-                            self.current_data[line_metric][metric_name] = row
-                        else:
-                            parsed_value = self._parse_field(line_metric, metric_key, metric_value)
-                            if parsed_value is not None:
-                                row[metric_key] = parsed_value
-
-                    else:
-                        parsed_value = self._parse_field(line_metric, metric_key, metric_value)
-                        if parsed_value is not None:
-                            self.current_data[line_metric][metric_key] = parsed_value
-
-                return True
-
-        return False
+_RECORD_SIZE = 76
+_RECORD_FMT = '<IHHHHiiiiiii'  # curtime flags sf0 sf1 sf2 scomplen pcomplen interval nlist npresent _ nexit
+_SSTAT_MEM_OFF = 7096          # offset of memstat within decompressed sstat
+_SSTAT_INTF_OFF = 8176         # offset of IntfStat (nrintf + intf array)
+_PERINTF_SIZE = 248
+_SSTAT_DSK_OFF = 16116         # offset of DskStat (ndsk + dsk array)
+_PERDSK_SIZE = 112
+_MAXDSKNAM = 32
 
 
-class AtopReader(object):
+def _read_record(f):
+    """Read one raw record header. Returns None on EOF."""
+    raw = f.read(_RECORD_SIZE)
+    if not raw or len(raw) < _RECORD_SIZE:
+        return None
+    vals = struct.unpack_from(_RECORD_FMT, raw)
+    return {
+        'curtime': vals[0],
+        'scomplen': vals[5],
+        'pcomplen': vals[6],
+        'nlist': vals[8],
+        'nexit': vals[11],
+    }
 
-    def __init__(self, path_schema, atop_binary="atop -f -r {path}"):
-        self._atop_binary = atop_binary
+
+def _parse_sstat(data, pagesize):
+    """Extract system-level metrics from a decompressed sstat buffer."""
+    result = {}
+
+    # CPL: load averages and context switches
+    nrcpu = struct.unpack_from('<q', data, 0)[0]
+    devint = struct.unpack_from('<q', data, 8)[0]
+    csw = struct.unpack_from('<q', data, 16)[0]
+    lavg1 = struct.unpack_from('<f', data, 32)[0]
+    lavg5 = struct.unpack_from('<f', data, 36)[0]
+    lavg15 = struct.unpack_from('<f', data, 40)[0]
+    result['CPL'] = {
+        'avg1': round(float(lavg1), 2),
+        'avg5': round(float(lavg5), 2),
+        'avg15': round(float(lavg15), 2),
+        'csw': int(csw),
+        'intr': int(devint),
+    }
+
+    # CPU: percentages from 'all' percpu struct (packed layout, starts at offset 76)
+    # cpunr(int32)@76 + stime(int64)@80 + utime@88 + ntime@96 + itime@104 + wtime@112 + Itime@120 + ...
+    all_off = 76
+    all_stime = struct.unpack_from('<q', data, all_off + 4)[0]
+    all_utime = struct.unpack_from('<q', data, all_off + 12)[0]
+    all_ntime = struct.unpack_from('<q', data, all_off + 20)[0]
+    all_itime = struct.unpack_from('<q', data, all_off + 28)[0]
+    all_wtime = struct.unpack_from('<q', data, all_off + 36)[0]
+    all_Itime = struct.unpack_from('<q', data, all_off + 44)[0]
+    total = all_stime + all_utime + all_ntime + all_itime + all_wtime + all_Itime
+    if total > 0:
+        result['CPU'] = {
+            'sys': int(100 * all_stime / total),
+            'user': int(100 * (all_utime + all_ntime) / total),
+            'idle': int(100 * all_itime / total),
+            'wait': int(100 * all_wtime / total),
+            'irq': int(100 * all_Itime / total),
+        }
+
+    # MEM and SWP
+    M = _SSTAT_MEM_OFF
+    physmem = struct.unpack_from('<q', data, M)[0] * pagesize
+    freemem = struct.unpack_from('<q', data, M + 8)[0] * pagesize
+    buffermem = struct.unpack_from('<q', data, M + 16)[0] * pagesize
+    slabmem = struct.unpack_from('<q', data, M + 24)[0] * pagesize
+    cachemem = struct.unpack_from('<q', data, M + 32)[0] * pagesize
+    totswap = struct.unpack_from('<q', data, M + 48)[0] * pagesize
+    freeswap = struct.unpack_from('<q', data, M + 56)[0] * pagesize
+    pgscans = struct.unpack_from('<q', data, M + 64)[0]
+    allocstall = struct.unpack_from('<q', data, M + 72)[0]
+    swouts = struct.unpack_from('<q', data, M + 80)[0]
+    swins = struct.unpack_from('<q', data, M + 88)[0]
+    commitlim = struct.unpack_from('<q', data, M + 96)[0] * pagesize
+    committed = struct.unpack_from('<q', data, M + 104)[0] * pagesize
+    result['MEM'] = {
+        'tot': physmem,
+        'free': freemem,
+        'buff': buffermem,
+        'cache': cachemem,
+        'slab': slabmem,
+    }
+    result['SWP'] = {
+        'tot': totswap,
+        'free': freeswap,
+        'vmcom': committed,
+        'vmlim': commitlim,
+    }
+    result['PAG'] = {
+        'scan': int(pgscans),
+        'stall': int(allocstall),
+        'swout': int(swouts),
+        'swin': int(swins),
+    }
+
+    # NET interfaces
+    nrintf = struct.unpack_from('<i', data, _SSTAT_INTF_OFF)[0]
+    net = {}
+    for i in range(nrintf):
+        base = _SSTAT_INTF_OFF + 4 + i * _PERINTF_SIZE
+        name = data[base:base + 16].rstrip(b'\x00').decode(errors='ignore')
+        if not name:
+            continue
+        rbyte = struct.unpack_from('<q', data, base + 16)[0]
+        rpack = struct.unpack_from('<q', data, base + 24)[0]
+        sbyte = struct.unpack_from('<q', data, base + 112)[0]
+        spack = struct.unpack_from('<q', data, base + 120)[0]
+        net[name] = {
+            'pcki': int(rpack),
+            'pcko': int(spack),
+            'si': int(rbyte),
+            'so': int(sbyte),
+        }
+    if net:
+        result['NET'] = net
+
+    # DSK
+    ndsk = struct.unpack_from('<i', data, _SSTAT_DSK_OFF)[0]
+    dsk = {}
+    for i in range(ndsk):
+        base = _SSTAT_DSK_OFF + 16 + i * _PERDSK_SIZE
+        name = data[base:base + _MAXDSKNAM].rstrip(b'\x00').decode(errors='ignore')
+        if not name:
+            continue
+        nread = struct.unpack_from('<q', data, base + _MAXDSKNAM)[0]
+        nwrite = struct.unpack_from('<q', data, base + _MAXDSKNAM + 8)[0]
+        io_ms = struct.unpack_from('<q', data, base + _MAXDSKNAM + 16)[0]
+        dsk[name] = {
+            'read': int(nread),
+            'write': int(nwrite),
+            'avio': io_ms / 1000.0 if io_ms else 0.0,
+        }
+    if dsk:
+        result['DSK'] = dsk
+
+    return result
+
+
+class AtopBinaryReader(object):
+
+    def __init__(self, path_schema):
         self._path_schema = path_schema
+        # When no strptime placeholders are present, the path is a literal file/glob,
+        # so the time-range filter should not be applied.
+        self._filter_by_time = '%' in path_schema
 
     def required_file_paths(self, begin, end):
+        if not self._filter_by_time:
+            for path in sorted(glob.glob(self._path_schema) or [self._path_schema]):
+                yield path
+            return
 
         file_name_list = glob.glob(re.sub(r'%[aAwdbBmyYHIpMSfzZjUWcxX]', '*', self._path_schema).replace('**', '*'))
-        available_times = sorted(datetime.strptime(file_name, self._path_schema) for file_name in file_name_list)
+        available_times = sorted(datetime.strptime(fn, self._path_schema) for fn in file_name_list)
 
         for file_index, file_time in enumerate(available_times):
             if file_time < end:
                 if len(available_times) > file_index + 1 and available_times[file_index + 1] > begin:
-                    # the next item is within the time frame,
                     yield file_time.strftime(self._path_schema)
                 elif len(available_times) == file_index + 1:
-                    # there is no next item but this is the last item within the time frame
                     yield file_time.strftime(self._path_schema)
 
-    def atop_log_files(self, begin, end):
-        for file_path in self.required_file_paths(begin, end):
-            yield subprocess.Popen(self._atop_binary.format(path=file_path), stdout=subprocess.PIPE, shell=True).stdout
+    def read(self, begin, end):
+        """Yield (datetime, metrics_dict) for each sample in [begin, end]."""
+        from atoparser.structs import atop_1_26
+        import ctypes
+
+        for path in self.required_file_paths(begin, end):
+            try:
+                f = open(path, 'rb')
+            except OSError:
+                continue
+
+            with f:
+                header = atop_1_26.Header()
+                f.readinto(header)
+                pagesize = header.pagesize
+
+                first_record = True
+                while True:
+                    rec = _read_record(f)
+                    if rec is None:
+                        break
+
+                    try:
+                        sstat_raw = zlib.decompress(f.read(rec['scomplen']))
+                        f.read(rec['pcomplen'])  # skip pstat (per-process data)
+                    except zlib.error:
+                        break
+
+                    ts = datetime.fromtimestamp(rec['curtime'])
+
+                    # Skip the first record in each file: it holds cumulative-since-boot
+                    # counters rather than per-interval deltas.
+                    if first_record:
+                        first_record = False
+                        continue
+
+                    if self._filter_by_time and (ts < begin or ts > end):
+                        continue
+
+                    metrics = _parse_sstat(sstat_raw, pagesize)
+                    metrics['PRC'] = {
+                        'proc': rec['nlist'],
+                        'exit': rec['nexit'],
+                    }
+                    yield ts, metrics
 
 
 def main():
@@ -274,42 +266,43 @@ def main():
     metrics = arguments['<metric>'] or ['CPL.avg5']
     end = iso8601.parse_date(arguments['--end'], default_timezone=None)
     begin = end - timedelta(hours=time_range)
-    reader = AtopReader(arguments['--path'], arguments['--cmd'])
+    reader = AtopBinaryReader(arguments['--path'])
 
-    with AtopParser(begin, end) as parser:
+    result = OrderedDict()
+    for ts, data in reader.read(begin, end):
+        result[ts] = data
 
-        for log_file in reader.atop_log_files(begin, end):
-            for line in log_file:
-                    parser.add_line(line.decode())
-
-    if not len(parser.result):
+    if not len(result):
         sys.stderr.write('empty result\n')
         sys.exit(1)
 
     elif arguments['metrics']:
 
-        for metric in parser.available_metric_paths:
-            print(metric)
+        metric_paths = set()
+        for entry in result.values():
+            py_.map_values_deep(entry, lambda __, path: metric_paths.add(tuple(path)))
+        for path in sorted(metric_paths):
+            print('.'.join(path))
 
     elif arguments['table']:
 
         from tabulate import tabulate
         print(tabulate([[time] + [py_.get(value, metric) for metric in metrics]
-                        for time, value in parser.result.items()],
+                        for time, value in result.items()],
                        ['time'] + metrics, tablefmt="plain"))
 
     elif arguments['json']:
 
         from json import dumps
         print(dumps({time.isoformat(): {metric: py_.get(value, metric) for metric in metrics}
-                     for time, value in parser.result.items()}))
+                     for time, value in result.items()}))
 
     elif arguments['csv']:
 
         import csv
         writer = csv.writer(sys.stdout)
         writer.writerow(['time'] + metrics)
-        for time, value in parser.result.items():
+        for time, value in result.items():
             writer.writerow([time.isoformat()] + [py_.get(value, metric) for metric in metrics])
 
     elif arguments['gnuplot']:
@@ -319,7 +312,8 @@ def main():
             width = int(arguments['--width'])
             height = int(arguments['--height'])
 
-            process = subprocess.Popen(["gnuplot"], stdin=subprocess.PIPE)
+            import subprocess as sp
+            process = sp.Popen(["gnuplot"], stdin=sp.PIPE)
 
             process.stdin.write(b"set term dumb %d %d \n" % (width, height))
             process.stdin.write(b"unset border \n")
@@ -335,9 +329,9 @@ def main():
             process.stdin.write(b"set datafile sep '\t' \n")
             process.stdin.write(b"plot '-' using 1:2 notitle with linespoints \n")
 
-            for time, value in parser.result.items():
+            for time, value in result.items():
                 process.stdin.write(b"%s\t%s\n" % (str(time.isoformat()).encode('utf-8'),
-                                                   str(py_.get(value, metric)).encode('utf-8')))
+                                                    str(py_.get(value, metric)).encode('utf-8')))
 
             process.stdin.write(b"e\n")
             process.stdin.flush()
@@ -356,9 +350,9 @@ def main():
             batch = False
             color = False
             encoding = 'utf-8'
-            function = None  # None or any of diagram.FUNCTION.keys()
+            function = None
             legend = True
-            palette = None  # None or any of diagram.PALETTE.keys()
+            palette = None
             reverse = False
 
             def __init__(self, **kwargs):
@@ -366,7 +360,7 @@ def main():
 
         for metric in metrics:
             engine = diagram.AxisGraph(diagram.Point((width, height)), DiagramOptions())
-            engine.update([py_.get(value, metric) for value in parser.result.values()])
+            engine.update([py_.get(value, metric) for value in result.values()])
             if hasattr(sys.stdout, 'buffer'):
                 engine.render(sys.stdout.buffer)
             else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 iso8601==0.1.12
 pydash==6.0.0
-humanfriendly==4.12.1
+atoparser>=3.3.1
 tabulate==0.8.2
 diagram==0.2.25
 docopt==0.6.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
-iso8601==0.1.12
 pydash==6.0.0
 atoparser>=3.3.1
-tabulate==0.8.2
+tabulate>=0.9.0
 diagram==0.2.25

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,3 @@ pydash==6.0.0
 atoparser>=3.3.1
 tabulate==0.8.2
 diagram==0.2.25
-docopt==0.6.2

--- a/setup.py
+++ b/setup.py
@@ -16,9 +16,13 @@ setup(
                 "aplot=aplot.__main__:main",
             ]
     },
+    python_requires='>=3.10',
     classifiers=[
         'Development Status :: 1 - Planning',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
     ],
 )


### PR DESCRIPTION
replaced calling atop and text-parsing by reading the atop files directly. Now also supports other atop versions than the version installed
new commands to analyse data by users

some cleanup:
migrate docopt to argparse
removed iso8601, humanfriendly

assisted by Claude